### PR TITLE
update brew install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ It is free as in open-source. Should you like to motivate me, you may click on t
 
 ## Installation
 
-If you have [Homebrew](https://brew.sh), just run `brew cask install linkliar`.
+If you have [Homebrew](https://brew.sh), just run `brew install --cask linkliar`.
 
 To install it manually, follow [these instructions](http://halo.github.io/LinkLiar/installation.html).
 


### PR DESCRIPTION
brew recently disabled `brew cask install` and switch to `brew install --cask`. 

This PR updates the readme to use the new command.

You can see others talking about the change here: https://github.com/ansible-collections/community.general/issues/1524